### PR TITLE
Feat/#20/경품 추첨 기능 구현

### DIFF
--- a/src/main/java/softeer/team_pineapple_be/TeamPineappleBeApplication.java
+++ b/src/main/java/softeer/team_pineapple_be/TeamPineappleBeApplication.java
@@ -2,7 +2,9 @@ package softeer.team_pineapple_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TeamPineappleBeApplication {
 

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/controller/DrawController.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/controller/DrawController.java
@@ -1,0 +1,36 @@
+package softeer.team_pineapple_be.domain.draw.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.domain.draw.request.SendPrizeRequest;
+import softeer.team_pineapple_be.domain.draw.response.DrawResponse;
+import softeer.team_pineapple_be.domain.draw.service.DrawPrizeService;
+import softeer.team_pineapple_be.domain.draw.service.DrawService;
+import softeer.team_pineapple_be.global.common.response.SuccessResponse;
+
+/**
+ * 경품 추첨 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/draw")
+public class DrawController {
+  private final DrawService drawService;
+  private final DrawPrizeService drawPrizeService;
+
+  @PostMapping
+  public ResponseEntity<DrawResponse> enterDraw() {
+    return ResponseEntity.ok(drawService.enterDraw());
+  }
+
+  @PostMapping("/rewards/send-prize")
+  public ResponseEntity<SuccessResponse> sendPrize(@RequestBody SendPrizeRequest request) {
+    drawPrizeService.sendPrizeMessage(request.getPrizeId());
+    return ResponseEntity.ok(new SuccessResponse());
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawDailyMessageInfo.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawDailyMessageInfo.java
@@ -1,0 +1,38 @@
+package softeer.team_pineapple_be.domain.draw.domain;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 일자별 메시지 정보 엔티티
+ */
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DrawDailyMessageInfo {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false)
+  private Integer Id;
+  @Column(nullable = false)
+  private String winMessage;
+  @Column(nullable = false)
+  private String loseMessage;
+  @Column(nullable = false)
+  private String loseScenario;
+  @Column(nullable = false)
+  private String winImage;
+  @Column(nullable = false)
+  private String loseImage;
+  @Column(nullable = false)
+  private LocalDate drawDate;
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawHistory.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawHistory.java
@@ -1,0 +1,32 @@
+package softeer.team_pineapple_be.domain.draw.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import softeer.team_pineapple_be.global.common.domain.BaseTimeEntity;
+
+/**
+ * 경품 추첨 이력 엔티티
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+public class DrawHistory extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false)
+  private Long id;
+  @Column(nullable = false)
+  private Byte drawResult;
+  @Column(nullable = false)
+  private String phoneNumber;
+
+  public DrawHistory(Byte drawResult, String phoneNumber) {
+    this.drawResult = drawResult;
+    this.phoneNumber = phoneNumber;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawPrize.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawPrize.java
@@ -1,0 +1,32 @@
+package softeer.team_pineapple_be.domain.draw.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+/**
+ * 경품 QR코드나 바코드 사진 저장 엔티티
+ */
+@Entity
+@Getter
+public class DrawPrize {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private String image;
+  private Boolean valid;
+  private String owner;
+  @ManyToOne
+  private DrawRewardInfo drawRewardInfo;
+
+  public void invalidate() {
+    this.valid = false;
+  }
+
+  public void isNowOwnedBy(String phoneNumber) {
+    this.owner = phoneNumber;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawProbability.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawProbability.java
@@ -1,0 +1,23 @@
+package softeer.team_pineapple_be.domain.draw.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 당첨 확률 엔티티
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrawProbability {
+  @Id
+  @Column(nullable = false)
+  private Byte ranking;
+  @Column(nullable = false)
+  private Integer probability;
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawRewardInfo.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/domain/DrawRewardInfo.java
@@ -1,0 +1,35 @@
+package softeer.team_pineapple_be.domain.draw.domain;
+
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 경품 정보 엔티티 : 경품 이름, 경품 재고,경품 이미지
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrawRewardInfo {
+  @Id
+  @Column(nullable = false)
+  private Byte ranking;
+  @Column(nullable = false)
+  private String name;
+  @Column(nullable = false)
+  private Integer stock;
+  @OneToMany(mappedBy = "drawRewardInfo", fetch = FetchType.LAZY)
+  private List<DrawPrize> drawPrizes;
+
+  public void decreaseStock() {
+    stock--;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawDailyMessageInfoRepository.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawDailyMessageInfoRepository.java
@@ -1,0 +1,14 @@
+package softeer.team_pineapple_be.domain.draw.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+import softeer.team_pineapple_be.domain.draw.domain.DrawDailyMessageInfo;
+
+/**
+ * 일자별 경품 추첨 메시지 리포지토리
+ */
+public interface DrawDailyMessageInfoRepository extends JpaRepository<DrawDailyMessageInfo, Integer> {
+  public DrawDailyMessageInfo findByDrawDate(LocalDate drawDate);
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawHistoryRepository.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawHistoryRepository.java
@@ -1,0 +1,11 @@
+package softeer.team_pineapple_be.domain.draw.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import softeer.team_pineapple_be.domain.draw.domain.DrawHistory;
+
+/**
+ * 경품 추첨 이력 리포지토리
+ */
+public interface DrawHistoryRepository extends JpaRepository<DrawHistory, Long> {
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawPrizeRepository.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawPrizeRepository.java
@@ -1,0 +1,15 @@
+package softeer.team_pineapple_be.domain.draw.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+import softeer.team_pineapple_be.domain.draw.domain.DrawPrize;
+import softeer.team_pineapple_be.domain.draw.domain.DrawRewardInfo;
+
+/**
+ * 경품 리포지토리
+ */
+public interface DrawPrizeRepository extends JpaRepository<DrawPrize, Long> {
+  Optional<DrawPrize> findFirstByDrawRewardInfoAndValid(DrawRewardInfo drawRewardInfo, boolean valid);
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawProbabilityRepository.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawProbabilityRepository.java
@@ -1,0 +1,11 @@
+package softeer.team_pineapple_be.domain.draw.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import softeer.team_pineapple_be.domain.draw.domain.DrawProbability;
+
+/**
+ * 당첨 확률 리포지토리
+ */
+public interface DrawProbabilityRepository extends JpaRepository<DrawProbability, Byte> {
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawRewardInfoRepository.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/repository/DrawRewardInfoRepository.java
@@ -1,0 +1,11 @@
+package softeer.team_pineapple_be.domain.draw.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import softeer.team_pineapple_be.domain.draw.domain.DrawRewardInfo;
+
+/**
+ * 경품 정보 리포지토리
+ */
+public interface DrawRewardInfoRepository extends JpaRepository<DrawRewardInfo, Byte> {
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/request/SendPrizeRequest.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/request/SendPrizeRequest.java
@@ -1,0 +1,17 @@
+package softeer.team_pineapple_be.domain.draw.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 경품 발송 요청 객체
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendPrizeRequest {
+  private Long prizeId;
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/response/DrawLoseResponse.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/response/DrawLoseResponse.java
@@ -1,0 +1,29 @@
+package softeer.team_pineapple_be.domain.draw.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 경품 추첨 꽝 응답
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class DrawLoseResponse extends DrawResponse {
+  private String dailyLoseMessage;
+  private String dailyLoseScenario;
+  private String image;
+  private Boolean car;
+  private Integer toolBoxCount;
+
+  public DrawLoseResponse(String dailyLoseMessage, String dailyLoseScenario, String image, Boolean car,
+      Integer toolBoxCount) {
+    isDrawWin = false;
+    this.dailyLoseMessage = dailyLoseMessage;
+    this.dailyLoseScenario = dailyLoseScenario;
+    this.image = image;
+    this.car = car;
+    this.toolBoxCount = toolBoxCount;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/response/DrawResponse.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/response/DrawResponse.java
@@ -1,0 +1,13 @@
+package softeer.team_pineapple_be.domain.draw.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 경품 추첨 공통 응답
+ */
+@Getter
+@Setter
+public class DrawResponse {
+  Boolean isDrawWin;
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/response/DrawWinningResponse.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/response/DrawWinningResponse.java
@@ -1,0 +1,31 @@
+package softeer.team_pineapple_be.domain.draw.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 경품 추첨 당첨 응답
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class DrawWinningResponse extends DrawResponse {
+  private String dailyWinningMessage;
+  private String prizeName;
+  private String image;
+  private Long prizeId;
+  private Boolean car;
+  private Integer toolBoxCount;
+
+  public DrawWinningResponse(String dailyWinningMessage, String prizeName, String image, Long prizeId, Boolean car,
+      Integer toolBoxCount) {
+    isDrawWin = true;
+    this.dailyWinningMessage = dailyWinningMessage;
+    this.prizeName = prizeName;
+    this.image = image;
+    this.prizeId = prizeId;
+    this.car = car;
+    this.toolBoxCount = toolBoxCount;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/service/DrawPrizeService.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/service/DrawPrizeService.java
@@ -1,0 +1,31 @@
+package softeer.team_pineapple_be.domain.draw.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.domain.draw.domain.DrawPrize;
+import softeer.team_pineapple_be.domain.draw.repository.DrawPrizeRepository;
+import softeer.team_pineapple_be.global.auth.service.AuthMemberService;
+import softeer.team_pineapple_be.global.message.MessageService;
+
+/**
+ * 경품 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class DrawPrizeService {
+  private final DrawPrizeRepository drawPrizeRepository;
+  private final MessageService messageService;
+  private final AuthMemberService authMemberService;
+
+  @Transactional
+  public void sendPrizeMessage(Long prizeId) {
+    String memberPhoneNumber = authMemberService.getMemberPhoneNumber();
+    DrawPrize prize = drawPrizeRepository.findById(prizeId).orElseThrow(() -> new RuntimeException("상품 없음"));
+    if (!memberPhoneNumber.equals(prize.getOwner())) {
+      throw new RuntimeException("상품 소유자 아님");
+    }
+    messageService.sendPrizeImage(prize.getImage());
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/service/DrawService.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/service/DrawService.java
@@ -1,0 +1,91 @@
+package softeer.team_pineapple_be.domain.draw.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.domain.draw.domain.DrawDailyMessageInfo;
+import softeer.team_pineapple_be.domain.draw.domain.DrawHistory;
+import softeer.team_pineapple_be.domain.draw.domain.DrawPrize;
+import softeer.team_pineapple_be.domain.draw.domain.DrawRewardInfo;
+import softeer.team_pineapple_be.domain.draw.repository.DrawDailyMessageInfoRepository;
+import softeer.team_pineapple_be.domain.draw.repository.DrawHistoryRepository;
+import softeer.team_pineapple_be.domain.draw.repository.DrawPrizeRepository;
+import softeer.team_pineapple_be.domain.draw.repository.DrawRewardInfoRepository;
+import softeer.team_pineapple_be.domain.draw.response.DrawLoseResponse;
+import softeer.team_pineapple_be.domain.draw.response.DrawResponse;
+import softeer.team_pineapple_be.domain.draw.response.DrawWinningResponse;
+import softeer.team_pineapple_be.domain.member.domain.Member;
+import softeer.team_pineapple_be.domain.member.repository.MemberRepository;
+import softeer.team_pineapple_be.global.auth.service.AuthMemberService;
+
+/**
+ * 경품 추첨 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class DrawService {
+  private final DrawDailyMessageInfoRepository drawDailyMessageInfoRepository;
+  private final DrawHistoryRepository drawHistoryRepository;
+  private final DrawPrizeRepository drawPrizeRepository;
+  private final DrawRewardInfoRepository drawRewardInfoRepository;
+  private final AuthMemberService authMemberService;
+  private final MemberRepository memberRepository;
+  private final RandomDrawPrizeService randomDrawPrizeService;
+
+  /**
+   * 경품 추첨 수행하는 메서드
+   *
+   * @return 경품에 대한 정보 응답 객체
+   */
+  @Transactional
+  public DrawResponse enterDraw() {
+    String memberPhoneNumber = authMemberService.getMemberPhoneNumber();
+    Member member =
+        memberRepository.findById(memberPhoneNumber).orElseThrow(() -> new RuntimeException("member not found"));
+    canEnterDraw(member);
+    member.decrementToolBoxCnt();
+    Byte prizeRank = randomDrawPrizeService.drawPrize();
+    DrawRewardInfo rewardInfo =
+        drawRewardInfoRepository.findById(prizeRank).orElseThrow(() -> new RuntimeException("prize not found"));
+    DrawDailyMessageInfo dailyMessageInfo = drawDailyMessageInfoRepository.findByDrawDate(LocalDate.now());
+    if (rewardInfo.getStock() == 0 || rewardInfo.getRanking() == 0) {
+      drawHistoryRepository.save(new DrawHistory((byte) 0, memberPhoneNumber));
+      return new DrawLoseResponse(dailyMessageInfo.getLoseMessage(), dailyMessageInfo.getLoseScenario(),
+          dailyMessageInfo.getLoseImage(), member.isCar(), member.getToolBoxCnt());
+    }
+    drawHistoryRepository.save(new DrawHistory(prizeRank, memberPhoneNumber));
+    rewardInfo.decreaseStock();
+    Long prizeId = setPrizeOwner(rewardInfo, memberPhoneNumber);
+    return new DrawWinningResponse(dailyMessageInfo.getWinMessage(), rewardInfo.getName(),
+        dailyMessageInfo.getWinImage(), prizeId, member.isCar(), member.getToolBoxCnt());
+  }
+
+  /**
+   * 경품 추첨 자격 있는지 확인
+   *
+   * @param member
+   */
+  private void canEnterDraw(Member member) {
+    if ((!member.isCar()) || (member.getToolBoxCnt() == 0)) {
+      throw new RuntimeException("can't enter draw");
+    }
+  }
+
+  /**
+   * 당첨된 경품에 소유자 설정
+   *
+   * @param rewardInfo
+   * @param memberPhoneNumber
+   * @return 경품 ID
+   */
+  private Long setPrizeOwner(DrawRewardInfo rewardInfo, String memberPhoneNumber) {
+    DrawPrize prize = drawPrizeRepository.findFirstByDrawRewardInfoAndValid(rewardInfo, true)
+                                         .orElseThrow(() -> new RuntimeException("재고에는 있다고 뜨는데 해당하는 경품이 없음"));
+    prize.isNowOwnedBy(memberPhoneNumber);
+    prize.invalidate();
+    return prize.getId();
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/service/RandomDrawPrizeService.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/service/RandomDrawPrizeService.java
@@ -1,0 +1,51 @@
+package softeer.team_pineapple_be.domain.draw.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.domain.draw.domain.DrawProbability;
+import softeer.team_pineapple_be.domain.draw.repository.DrawProbabilityRepository;
+import softeer.team_pineapple_be.global.common.utils.RandomUtils;
+
+/**
+ * 랜덤 추첨 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class RandomDrawPrizeService {
+  private final DrawProbabilityRepository drawProbabilityRepository;
+  private byte[] probabilityArray;
+
+  /**
+   * 랜덤 숫자로 경품 선택
+   *
+   * @return 경품 랭크
+   */
+  public Byte drawPrize() {
+    Integer randomIndex = RandomUtils.getSecureRandomNumberLessThen(probabilityArray.length);
+    return probabilityArray[randomIndex];
+  }
+
+  /**
+   * 추첨 배열 초기화
+   */
+  @PostConstruct
+  public void init() {
+    List<DrawProbability> probabilityList = drawProbabilityRepository.findAll();
+    int probabilitySum = 0;
+    for (DrawProbability drawProbability : probabilityList) {
+      probabilitySum += drawProbability.getProbability();
+    }
+    probabilityArray = new byte[probabilitySum];
+    int index = 0;
+    for (DrawProbability drawProbability : probabilityList) {
+      Integer probability = drawProbability.getProbability();
+      for (int i = 0; i < probability; i++) {
+        probabilityArray[index++] = drawProbability.getRanking();
+      }
+    }
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/member/domain/Member.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/member/domain/Member.java
@@ -29,8 +29,8 @@ public class Member {
     car = false;
   }
 
-  public void incrementToolBoxCnt() {
-    this.toolBoxCnt += 1;
+  public void decrementToolBoxCnt() {
+    this.toolBoxCnt -= 1;
   }
 
   /**
@@ -38,5 +38,9 @@ public class Member {
    */
   public void generateCar() {
     this.car = true;
+  }
+
+  public void incrementToolBoxCnt() {
+    this.toolBoxCnt += 1;
   }
 }

--- a/src/main/java/softeer/team_pineapple_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/member/repository/MemberRepository.java
@@ -7,6 +7,6 @@ import softeer.team_pineapple_be.domain.member.domain.Member;
 /**
  * 멤버 리포지토리
  */
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, String> {
   public Member findByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/softeer/team_pineapple_be/global/common/utils/RandomUtils.java
+++ b/src/main/java/softeer/team_pineapple_be/global/common/utils/RandomUtils.java
@@ -11,7 +11,11 @@ import lombok.experimental.UtilityClass;
 public class RandomUtils {
   private static final SecureRandom secureRandom = new SecureRandom();
 
-  public Integer getAuthCode(){
+  public Integer getAuthCode() {
     return 100000 + secureRandom.nextInt(900000);
+  }
+
+  public Integer getSecureRandomNumberLessThen(int max) {
+    return secureRandom.nextInt(max);
   }
 }

--- a/src/main/java/softeer/team_pineapple_be/global/message/MessageService.java
+++ b/src/main/java/softeer/team_pineapple_be/global/message/MessageService.java
@@ -1,0 +1,19 @@
+package softeer.team_pineapple_be.global.message;
+
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 메시지 서비스 인터페이스
+ */
+@Service
+@Slf4j
+public class MessageService {
+  public boolean sendPrizeImage(String message) {
+    //TODO : 이후 SDK 사용해서 경품 이미지 보내는 로직 구현해야함
+    //TODO : S3에서 받아와서 보내기
+    log.info("경품 이미지 발송!");
+    return true;
+  }
+}


### PR DESCRIPTION
### 구현 기능
- 경품 관련 엔티티들 구현
    - 일자별 메시지 정보
    - 경품 추첨 참여및 결과 이력
    - 경품 QR코드 저장
    - 경품 정보
- 경품 관련 리포지토리들 구현
- 경품 난수 생성 기능 구현
- 경품 추첨 객체를 Bean생명주기 콜백을 사용하여 초기화
- 경품 공통 응답 객체, 당첨 응답객체 ,실패 응답객체 생성
- 경품 랜덤 추첨 서비스
    - 랜덤 난수를 통해 경품 고르는 기능 구현
- 경품 추첨 서비스
    - 툴박스와 자동차 있는지 확인
    - 추첨에 참여하면 툴박스 감소
    - 당첨되면 해당 경품의 소유자를 당첨자로 바꾸고 재고를 하나 줄임
    - 만약 재고가 없는 경품에 당첨되면 꽝으로 응답
- 경품 서비스
    - 자신이 당첨된 경품의 QR코드를 발송받는 기능
    - 만약 경품 당첨자가 아니라면 못받도록 구현

### 사소한 수정
- JPA Auditing 허용 설정

close #20