### PR TITLE
Feat/#31/인증 방식을 JWT 인증으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,11 @@ dependencies {
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/softeer/team_pineapple_be/domain/comment/controller/CommentController.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/comment/controller/CommentController.java
@@ -1,6 +1,5 @@
 package softeer.team_pineapple_be.domain.comment.controller;
 
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +12,13 @@ import java.time.LocalDate;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import softeer.team_pineapple_be.domain.comment.request.CommentLikeRequest;
 import softeer.team_pineapple_be.domain.comment.request.CommentRequest;
 import softeer.team_pineapple_be.domain.comment.response.CommentPageResponse;
 import softeer.team_pineapple_be.domain.comment.service.CommentService;
+import softeer.team_pineapple_be.global.auth.annotation.Auth;
 import softeer.team_pineapple_be.global.common.response.SuccessResponse;
 
 /**
@@ -30,6 +31,7 @@ import softeer.team_pineapple_be.global.common.response.SuccessResponse;
 public class CommentController {
   private final CommentService commentService;
 
+  @Auth
   @Operation(summary = "기대평 남기기")
   @PostMapping
   public ResponseEntity<SuccessResponse> addComment(@Valid @RequestBody CommentRequest commentRequest) {
@@ -37,6 +39,7 @@ public class CommentController {
     return ResponseEntity.ok(new SuccessResponse());
   }
 
+  @Auth
   @Operation(summary = "좋아요 누르기")
   @PostMapping("/likes")
   public ResponseEntity<SuccessResponse> addLikes(@Valid @RequestBody CommentLikeRequest commentLikeRequest) {

--- a/src/main/java/softeer/team_pineapple_be/domain/draw/controller/DrawController.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/draw/controller/DrawController.java
@@ -1,17 +1,18 @@
 package softeer.team_pineapple_be.domain.draw.controller;
 
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import softeer.team_pineapple_be.domain.draw.request.SendPrizeRequest;
 import softeer.team_pineapple_be.domain.draw.response.DrawResponse;
 import softeer.team_pineapple_be.domain.draw.service.DrawPrizeService;
 import softeer.team_pineapple_be.domain.draw.service.DrawService;
+import softeer.team_pineapple_be.global.auth.annotation.Auth;
 import softeer.team_pineapple_be.global.common.response.SuccessResponse;
 
 /**
@@ -24,11 +25,13 @@ public class DrawController {
   private final DrawService drawService;
   private final DrawPrizeService drawPrizeService;
 
+  @Auth
   @PostMapping
   public ResponseEntity<DrawResponse> enterDraw() {
     return ResponseEntity.ok(drawService.enterDraw());
   }
 
+  @Auth
   @PostMapping("/rewards/send-prize")
   public ResponseEntity<SuccessResponse> sendPrize(@Valid @RequestBody SendPrizeRequest request) {
     drawPrizeService.sendPrizeMessage(request.getPrizeId());

--- a/src/main/java/softeer/team_pineapple_be/domain/member/controller/LoginController.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/member/controller/LoginController.java
@@ -13,8 +13,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import softeer.team_pineapple_be.domain.member.request.LoginAuthCodeRequest;
 import softeer.team_pineapple_be.domain.member.request.LoginPhoneNumberRequest;
-import softeer.team_pineapple_be.domain.member.response.MemberInfoResponse;
+import softeer.team_pineapple_be.domain.member.response.MemberLoginInfoResponse;
 import softeer.team_pineapple_be.domain.member.service.MemberAuthorizationService;
+import softeer.team_pineapple_be.global.auth.annotation.Auth;
 import softeer.team_pineapple_be.global.common.response.SuccessResponse;
 
 /**
@@ -37,16 +38,15 @@ public class LoginController {
 
   @Operation(summary = "인증번호 입력해서 인증")
   @PostMapping("/login/code")
-  public ResponseEntity<MemberInfoResponse> loginWithAuthCode(
+  public ResponseEntity<MemberLoginInfoResponse> loginWithAuthCode(
       @Valid @RequestBody LoginAuthCodeRequest loginAuthCodeRequest, HttpServletRequest request) {
-    MemberInfoResponse memberInfoResponse =
+    MemberLoginInfoResponse memberLoginInfoResponse =
         memberAuthorizationService.loginWithAuthCode(loginAuthCodeRequest.getPhoneNumber(),
             loginAuthCodeRequest.getCode());
-    HttpSession session = request.getSession();
-    session.setAttribute("phoneNumber", memberInfoResponse.getPhoneNumber());
-    return ResponseEntity.ok(memberInfoResponse);
+    return ResponseEntity.ok(memberLoginInfoResponse);
   }
 
+  @Auth
   @Operation(summary = "로그아웃")
   @PostMapping("/logout")
   public ResponseEntity<SuccessResponse> logout(HttpServletRequest request) {

--- a/src/main/java/softeer/team_pineapple_be/domain/member/domain/Member.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/member/domain/Member.java
@@ -23,10 +23,14 @@ public class Member {
   @Column(nullable = false)
   private boolean car;
 
+  @Column(nullable = false)
+  private String role;
+
   public Member(String phoneNumber) {
     this.phoneNumber = phoneNumber;
     toolBoxCnt = 0;
     car = false;
+    role = "USER";
   }
 
   public void decrementToolBoxCnt() {

--- a/src/main/java/softeer/team_pineapple_be/domain/member/response/MemberLoginInfoResponse.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/member/response/MemberLoginInfoResponse.java
@@ -1,0 +1,31 @@
+package softeer.team_pineapple_be.domain.member.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import softeer.team_pineapple_be.domain.member.domain.Member;
+
+/**
+ * 로그인했을 때 주는 응답
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class MemberLoginInfoResponse {
+  private String phoneNumber;
+  private Integer toolBoxCnt;
+  private boolean car;
+  private String accessToken;
+
+  /**
+   * 로그인한 유저에게 응답 주기
+   *
+   * @param member
+   * @return MemberInfoResponse
+   */
+  public static MemberLoginInfoResponse of(Member member, String accessToken) {
+    return new MemberLoginInfoResponse(member.getPhoneNumber(), member.getToolBoxCnt(), member.isCar(), accessToken);
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/domain/quiz/controller/QuizController.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/quiz/controller/QuizController.java
@@ -1,17 +1,22 @@
 package softeer.team_pineapple_be.domain.quiz.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import softeer.team_pineapple_be.domain.member.response.MemberInfoResponse;
 import softeer.team_pineapple_be.domain.quiz.request.QuizInfoRequest;
 import softeer.team_pineapple_be.domain.quiz.response.QuizContentResponse;
 import softeer.team_pineapple_be.domain.quiz.response.QuizInfoResponse;
 import softeer.team_pineapple_be.domain.quiz.service.QuizService;
+import softeer.team_pineapple_be.global.auth.annotation.Auth;
 
 @Tag(name = "Quiz 관련 정보 제공", description = "퀴즈에 대한 처리(내용, 정답)")
 @RestController
@@ -19,24 +24,25 @@ import softeer.team_pineapple_be.domain.quiz.service.QuizService;
 @RequestMapping("/quiz")
 public class QuizController {
 
-    private final QuizService quizService;
+  private final QuizService quizService;
 
-    @Operation(summary = "퀴즈 내용 가져오기")
-    @GetMapping
-    public ResponseEntity<QuizContentResponse> getQuizContent() {
-        return ResponseEntity.ok().body(quizService.getQuizContent());
-    }
+  @Operation(summary = "퀴즈 내용 가져오기")
+  @GetMapping
+  public ResponseEntity<QuizContentResponse> getQuizContent() {
+    return ResponseEntity.ok().body(quizService.getQuizContent());
+  }
 
-    @Operation(summary = "퀴즈 정답 맞추기")
-    @PostMapping("/answer")
-    public ResponseEntity<QuizInfoResponse> isCorrect(@Valid @RequestBody QuizInfoRequest quizInfoRequest) {
-        return ResponseEntity.ok().body(quizService.quizIsCorrect(quizInfoRequest));
-    }
+  @Operation(summary = "퀴즈 정답 맞추기")
+  @PostMapping("/answer")
+  public ResponseEntity<QuizInfoResponse> isCorrect(@Valid @RequestBody QuizInfoRequest quizInfoRequest) {
+    return ResponseEntity.ok().body(quizService.quizIsCorrect(quizInfoRequest));
+  }
 
-    @Operation(summary = "퀴즈 참여 여부 등록")
-    @GetMapping("/participants")
-    public ResponseEntity<MemberInfoResponse> setQuizHistory(){
-        return ResponseEntity.ok().body(quizService.quizHistory());
-    }
+  @Auth
+  @Operation(summary = "퀴즈 참여 여부 등록")
+  @GetMapping("/participants")
+  public ResponseEntity<MemberInfoResponse> setQuizHistory() {
+    return ResponseEntity.ok().body(quizService.quizHistory());
+  }
 
 }

--- a/src/main/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupController.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import softeer.team_pineapple_be.domain.worldcup.response.WorldCupParticipateResponse;
 import softeer.team_pineapple_be.domain.worldcup.service.WorldCupService;
+import softeer.team_pineapple_be.global.auth.annotation.Auth;
 import softeer.team_pineapple_be.global.common.response.SuccessResponse;
 
 /**
@@ -23,6 +24,7 @@ import softeer.team_pineapple_be.global.common.response.SuccessResponse;
 public class WorldCupController {
   private final WorldCupService worldCupService;
 
+  @Auth
   @Operation(summary = "월드컵 참여했는지 확인")
   @GetMapping("/participate")
   public ResponseEntity<WorldCupParticipateResponse> getParticipate() {
@@ -30,6 +32,7 @@ public class WorldCupController {
     return ResponseEntity.ok(worldCupParticipateResponse);
   }
 
+  @Auth
   @Operation(summary = "월드컵 참여 여부 등록")
   @PostMapping("/participate")
   public ResponseEntity<SuccessResponse> participate() {

--- a/src/main/java/softeer/team_pineapple_be/global/auth/annotation/Auth.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/annotation/Auth.java
@@ -1,0 +1,16 @@
+package softeer.team_pineapple_be.global.auth.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 인증 필요한지 결정하는 어노테이션
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface Auth {
+}

--- a/src/main/java/softeer/team_pineapple_be/global/auth/context/AuthContext.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/context/AuthContext.java
@@ -1,0 +1,18 @@
+package softeer.team_pineapple_be.global.auth.context;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 인증 컨텍스트 객체
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthContext {
+  private String phoneNumber;
+  private String role;
+}

--- a/src/main/java/softeer/team_pineapple_be/global/auth/context/AuthContextHolder.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/context/AuthContextHolder.java
@@ -1,0 +1,20 @@
+package softeer.team_pineapple_be.global.auth.context;
+
+/**
+ * 인증 컨텍스트 홀더
+ */
+public class AuthContextHolder {
+  private static final ThreadLocal<AuthContext> contextHolder = new ThreadLocal<>();
+
+  public static void clearContext() {
+    contextHolder.remove();
+  }
+
+  public static AuthContext getAuthContext() {
+    return contextHolder.get();
+  }
+
+  public static void setAuthContext(AuthContext authContext) {
+    contextHolder.set(authContext);
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/global/auth/exception/AuthErrorCode.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/exception/AuthErrorCode.java
@@ -14,7 +14,8 @@ import softeer.team_pineapple_be.global.exception.ErrorCode;
 public enum AuthErrorCode implements ErrorCode {
 
   NO_USER_INFO(HttpStatus.FORBIDDEN, "로그인이 되지 않았습니다"),
-  ;
+  JWT_PARSING_ERROR(HttpStatus.FORBIDDEN, "JWT 토큰을 파싱할 수 없습니다."),
+  JWT_EXPIRED(HttpStatus.FORBIDDEN, "JWT 토큰이 만료되었습니다");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/softeer/team_pineapple_be/global/auth/filter/ThreadLocalCleanerFilter.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/filter/ThreadLocalCleanerFilter.java
@@ -1,0 +1,39 @@
+package softeer.team_pineapple_be.global.auth.filter;
+
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import softeer.team_pineapple_be.global.auth.context.AuthContextHolder;
+
+/**
+ * 쓰레드 로컬 지우는 필터
+ */
+@Slf4j
+public class ThreadLocalCleanerFilter implements Filter {
+
+  @Override
+  public void destroy() {
+    Filter.super.destroy();
+  }
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    try {
+      filterChain.doFilter(servletRequest, servletResponse);
+    } finally {
+      AuthContextHolder.clearContext();
+    }
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    Filter.super.init(filterConfig);
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/global/auth/interceptor/JwtInterceptor.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/interceptor/JwtInterceptor.java
@@ -1,0 +1,49 @@
+package softeer.team_pineapple_be.global.auth.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.global.auth.annotation.Auth;
+import softeer.team_pineapple_be.global.auth.context.AuthContext;
+import softeer.team_pineapple_be.global.auth.context.AuthContextHolder;
+import softeer.team_pineapple_be.global.auth.exception.AuthErrorCode;
+import softeer.team_pineapple_be.global.auth.utils.JwtUtils;
+import softeer.team_pineapple_be.global.exception.RestApiException;
+
+/**
+ * JWT 인증 인터셉터
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+  private final JwtUtils jwtUtils;
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    if (!checkAnnotation(handler, Auth.class)) {
+      return true;
+    }
+    String authorization = request.getHeader("Authorization");
+    String token;
+    if (authorization == null || !authorization.startsWith("Bearer ")) {
+      throw new RestApiException(AuthErrorCode.JWT_PARSING_ERROR);
+    }
+    token = authorization.substring(7);
+    jwtUtils.isExpired(token);
+    AuthContextHolder.setAuthContext(new AuthContext(jwtUtils.getPhoneNumber(token), jwtUtils.getRole(token)));
+    return true;
+  }
+
+  private boolean checkAnnotation(Object handler, Class<Auth> authClass) {
+    HandlerMethod handlerMethod = (HandlerMethod) handler;
+    if (null != handlerMethod.getMethodAnnotation(authClass) ||
+        null != handlerMethod.getBeanType().getAnnotation(authClass)) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/global/auth/service/AuthMemberService.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/service/AuthMemberService.java
@@ -6,6 +6,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.global.auth.context.AuthContextHolder;
 import softeer.team_pineapple_be.global.auth.exception.AuthErrorCode;
 import softeer.team_pineapple_be.global.exception.RestApiException;
 
@@ -21,11 +22,11 @@ public class AuthMemberService {
    * @return 핸드폰 번호 String
    */
   public String getMemberPhoneNumber() {
-    Object phoneNumber = getCurrentRequest().getSession().getAttribute("phoneNumber");
+    String phoneNumber = AuthContextHolder.getAuthContext().getPhoneNumber();
     if (phoneNumber == null) {
       throw new RestApiException(AuthErrorCode.NO_USER_INFO);
     }
-    return (String) phoneNumber;
+    return phoneNumber;
   }
 
   private HttpServletRequest getCurrentRequest() {

--- a/src/main/java/softeer/team_pineapple_be/global/auth/utils/JwtUtils.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/utils/JwtUtils.java
@@ -1,0 +1,94 @@
+package softeer.team_pineapple_be.global.auth.utils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import io.jsonwebtoken.Jwts;
+import softeer.team_pineapple_be.global.auth.exception.AuthErrorCode;
+import softeer.team_pineapple_be.global.exception.RestApiException;
+
+/**
+ * JWT 유틸 클래스
+ */
+@Component
+public class JwtUtils {
+  private final SecretKey secretKey;
+
+  public JwtUtils(@Value("${spring.jwt.secret}") String secret) {
+    secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+  }
+
+  public String createJwt(String category, String phoneNumber, String role, Long expiredMs) {
+    return Jwts.builder()
+               .claim("category", category)
+               .claim("phoneNumber", phoneNumber)
+               .claim("role", role)
+               .issuedAt(new Date(System.currentTimeMillis()))
+               .expiration(new Date(System.currentTimeMillis() + expiredMs))
+               .signWith(secretKey)
+               .compact();
+  }
+
+  public String getCategory(String token) {
+    String category;
+    try {
+      category = Jwts.parser()
+                     .verifyWith(secretKey)
+                     .build()
+                     .parseSignedClaims(token)
+                     .getPayload()
+                     .get("category", String.class);
+    } catch (Exception e) {
+      throw new RestApiException(AuthErrorCode.JWT_PARSING_ERROR);
+    }
+    return category;
+  }
+
+  public String getPhoneNumber(String token) {
+    String phoneNumber;
+    try {
+      phoneNumber = Jwts.parser()
+                        .verifyWith(secretKey)
+                        .build()
+                        .parseSignedClaims(token)
+                        .getPayload()
+                        .get("phoneNumber", String.class);
+    } catch (Exception e) {
+      throw new RestApiException(AuthErrorCode.JWT_PARSING_ERROR);
+    }
+    return phoneNumber;
+  }
+
+  public String getRole(String token) {
+    String role;
+    try {
+      role =
+          Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    } catch (Exception e) {
+      throw new RestApiException(AuthErrorCode.JWT_PARSING_ERROR);
+    }
+    return role;
+  }
+
+  public Boolean isExpired(String token) {
+    boolean before;
+    try {
+      before = Jwts.parser()
+                   .verifyWith(secretKey)
+                   .build()
+                   .parseSignedClaims(token)
+                   .getPayload()
+                   .getExpiration()
+                   .before(new Date());
+    } catch (Exception e) {
+      throw new RestApiException(AuthErrorCode.JWT_EXPIRED);
+    }
+    return before;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/global/config/FilterConfig.java
+++ b/src/main/java/softeer/team_pineapple_be/global/config/FilterConfig.java
@@ -1,0 +1,21 @@
+package softeer.team_pineapple_be.global.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import softeer.team_pineapple_be.global.auth.filter.ThreadLocalCleanerFilter;
+
+/**
+ * 필터 설정
+ */
+@Configuration
+public class FilterConfig {
+  @Bean
+  public FilterRegistrationBean<ThreadLocalCleanerFilter> contextCleanerFilterRegistrationBean() {
+    FilterRegistrationBean<ThreadLocalCleanerFilter> registrationBean = new FilterRegistrationBean<>();
+    registrationBean.setFilter(new ThreadLocalCleanerFilter());
+    registrationBean.addUrlPatterns("/*");
+    return registrationBean;
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/global/config/InterceptorConfig.java
+++ b/src/main/java/softeer/team_pineapple_be/global/config/InterceptorConfig.java
@@ -1,0 +1,22 @@
+package softeer.team_pineapple_be.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.global.auth.interceptor.JwtInterceptor;
+
+/**
+ * 인터셉터 설정
+ */
+@RequiredArgsConstructor
+@Configuration
+public class InterceptorConfig implements WebMvcConfigurer {
+  private final JwtInterceptor jwtInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(jwtInterceptor);
+  }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feature/jwt

### 💡 작업동기
- 프론트엔드에서 쿠키를 등록할 수가 없다는 불만이 나왔음
- 어차피 이후에 서버 부하를 줄이기 위해 JWT로 변경할 생각이었기 때문에 지금 바꾸게 되었음

### 🔑 주요 변경사항
- JWT 인증 로직으로 변경
- 컨텍스트 정보를 ThreadLocal에 저장하도록 변경
- 인증을 인터셉터에서 처리
- 인증 여부를 Auth 어노테이션으로 지정하도록 설정
- 필터를 통해 http요청이 끝날 때 ThreadLocal을 비우도록 설정

### 관련 이슈

close #31 
