### PR TITLE
Feat/#38/WorldCup 테스트 코드 작성

### DIFF
--- a/src/test/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupControllerTest.java
+++ b/src/test/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupControllerTest.java
@@ -1,4 +1,69 @@
 package softeer.team_pineapple_be.domain.worldcup.controller;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import softeer.team_pineapple_be.domain.worldcup.response.WorldCupParticipateResponse;
+import softeer.team_pineapple_be.domain.worldcup.service.WorldCupService;
+import softeer.team_pineapple_be.global.common.response.SuccessResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public class WorldCupControllerTest {
+
+    @InjectMocks
+    private WorldCupController worldCupController;
+
+    @Mock
+    private WorldCupService worldCupService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(worldCupController).build();
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void getParticipate_ReturnsOk_WhenMemberParticipated() throws Exception {
+        // given
+        WorldCupParticipateResponse response = new WorldCupParticipateResponse(true);
+        when(worldCupService.isMemberParticipated()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/worldcup/participate")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.car").value(true)); // 응답의 car 필드 검증
+    }
+
+    @Test
+    void participate_ReturnsOk_WhenParticipationIsSuccessful() throws Exception {
+        // given
+        doNothing().when(worldCupService).participateWorldCup();
+        SuccessResponse successResponse = new SuccessResponse();
+
+        // when & then
+        mockMvc.perform(post("/worldcup/participate")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(successResponse.getStatus())) // status 필드 검증
+                .andExpect(jsonPath("$.message").value(successResponse.getMessage())); // message 필드 검증
+    }
 }

--- a/src/test/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupControllerTest.java
+++ b/src/test/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -41,6 +42,7 @@ public class WorldCupControllerTest {
     }
 
     @Test
+    @DisplayName("/worldcup/participate의 get 요청 api 요청에 대한 응답 테스트 - SuccessCase")
     void getParticipate_ReturnsOk_WhenMemberParticipated() throws Exception {
         // given
         WorldCupParticipateResponse response = new WorldCupParticipateResponse(true);
@@ -54,6 +56,7 @@ public class WorldCupControllerTest {
     }
 
     @Test
+    @DisplayName("/worldcup/participate의 post 요청 api 요청에 대한 응답 테스트 - SuccessCase")
     void participate_ReturnsOk_WhenParticipationIsSuccessful() throws Exception {
         // given
         doNothing().when(worldCupService).participateWorldCup();

--- a/src/test/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupControllerTest.java
+++ b/src/test/java/softeer/team_pineapple_be/domain/worldcup/controller/WorldCupControllerTest.java
@@ -1,0 +1,4 @@
+package softeer.team_pineapple_be.domain.worldcup.controller;
+
+public class WorldCupControllerTest {
+}

--- a/src/test/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupServiceTest.java
+++ b/src/test/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupServiceTest.java
@@ -1,6 +1,7 @@
 package softeer.team_pineapple_be.domain.worldcup.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -38,6 +39,7 @@ public class WorldCupServiceTest {
     }
 
     @Test
+    @DisplayName("멤버가 월드컵에 참여한 기록이 있는지 테스트 - SuccessCase")
     void isMemberParticipated_MemberExists_ReturnsWorldCupParticipateResponse() {
         // given
         when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
@@ -53,6 +55,7 @@ public class WorldCupServiceTest {
     }
 
     @Test
+    @DisplayName("멤버가 월드컵에 참여한 기록이 있는지 확인할 때 멤버가 없는 경우 테스트 - FailureCase")
     void isMemberParticipated_MemberDoesNotExist_ThrowsException() {
         // given
         when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
@@ -69,6 +72,7 @@ public class WorldCupServiceTest {
     }
 
     @Test
+    @DisplayName("멤버가 월드컵 참여하는 경우 테스트 - SuccessCase")
     void participateWorldCup_MemberExists_ReturnsOk() {
         // given
         when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
@@ -84,6 +88,7 @@ public class WorldCupServiceTest {
     }
 
     @Test
+    @DisplayName("멤버가 월드컵 참여할 떄 멤버가 없는 경우 테스트 - FailureCase")
     void participateWorldCup_MemberDoesNotExist_ThrowsRestApiException() {
         // given
         when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);

--- a/src/test/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupServiceTest.java
+++ b/src/test/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupServiceTest.java
@@ -1,0 +1,100 @@
+package softeer.team_pineapple_be.domain.worldcup.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import softeer.team_pineapple_be.domain.member.domain.Member;
+import softeer.team_pineapple_be.domain.member.exception.MemberErrorCode;
+import softeer.team_pineapple_be.domain.member.repository.MemberRepository;
+import softeer.team_pineapple_be.domain.worldcup.response.WorldCupParticipateResponse;
+import softeer.team_pineapple_be.global.auth.service.AuthMemberService;
+import softeer.team_pineapple_be.global.exception.RestApiException;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WorldCupServiceTest {
+
+    @InjectMocks
+    private WorldCupService worldCupService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AuthMemberService authMemberService;
+
+    private Member member;
+    private String phoneNumber;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        phoneNumber = "010-1234-5678";
+        member = new Member(phoneNumber);
+    }
+
+    @Test
+    void isMemberParticipated_MemberExists_ReturnsWorldCupParticipateResponse() {
+        // given
+        when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
+        when(memberRepository.findByPhoneNumber(phoneNumber)).thenReturn(java.util.Optional.of(member));
+
+        // when
+        WorldCupParticipateResponse response = worldCupService.isMemberParticipated();
+
+        // then
+        assertThat(response.getCar()).isFalse(); // AssertJ 사용
+        verify(authMemberService).getMemberPhoneNumber();
+        verify(memberRepository).findByPhoneNumber(phoneNumber);
+    }
+
+    @Test
+    void isMemberParticipated_MemberDoesNotExist_ThrowsException() {
+        // given
+        when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
+        when(memberRepository.findByPhoneNumber(phoneNumber)).thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> worldCupService.isMemberParticipated()) // AssertJ 사용
+                .isInstanceOf(RestApiException.class)
+                .satisfies(exception -> {
+                    RestApiException restApiException = (RestApiException) exception; // 캐스팅
+                    assertThat(restApiException.getErrorCode()).isEqualTo(MemberErrorCode.NO_MEMBER);
+                });
+
+    }
+
+    @Test
+    void participateWorldCup_MemberExists_ReturnsOk() {
+        // given
+        when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
+        when(memberRepository.findByPhoneNumber(phoneNumber)).thenReturn(java.util.Optional.of(member));
+
+        // when
+        worldCupService.participateWorldCup();
+
+        // then
+        assertThat(member.isCar()).isTrue(); // AssertJ 사용
+        verify(authMemberService).getMemberPhoneNumber();
+        verify(memberRepository).findByPhoneNumber(phoneNumber);
+    }
+
+    @Test
+    void participateWorldCup_MemberDoesNotExist_ThrowsRestApiException() {
+        // given
+        when(authMemberService.getMemberPhoneNumber()).thenReturn(phoneNumber);
+        when(memberRepository.findByPhoneNumber(phoneNumber)).thenReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> worldCupService.isMemberParticipated()) // AssertJ 사용
+                .isInstanceOf(RestApiException.class)
+                .satisfies(exception -> {
+                    RestApiException restApiException = (RestApiException) exception; // 캐스팅
+                    assertThat(restApiException.getErrorCode()).isEqualTo(MemberErrorCode.NO_MEMBER);
+                });
+    }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feature/worldcup-test

### 💡 작업동기
- worldcup 도메인 컨트롤러, 서비스 테스트 코드 작성

### 🔑 주요 변경사항
- worldcup 도메인을 assertJ를 이용한 테스트 코드 작성
- 예외처리 테스트 작성

### 관련 이슈
- #38 
