### PR TITLE
[FIX] PreFlight 요청 막히는 버그 안잡혀서 다시 수정

### DIFF
--- a/src/main/java/softeer/team_pineapple_be/global/auth/interceptor/JwtInterceptor.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/interceptor/JwtInterceptor.java
@@ -25,6 +25,9 @@ public class JwtInterceptor implements HandlerInterceptor {
 
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
+      return true;
+    }
     if (!checkAnnotation(handler, Auth.class)) {
       return true;
     }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/cors

### 💡 작업동기
- PreFlight요청을 정적 리소스 반환으로 착각하여 ResourceHttpRequestHandler를 따로 처리해줬는데, 해결이 되지 않았다.

### 🔑 주요 변경사항
- JWTInterceptor에서 OPTION 메서드로 요청은 바로 통과시키도록 변경

### 관련 이슈
- #41 
