### PR TITLE
[FEAT] 레디스를 이용하여 자신이 누른 좋아요 정보를 기대평 응답에 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/softeer/team_pineapple_be/domain/comment/domain/Comment.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/comment/domain/Comment.java
@@ -37,6 +37,10 @@ public class Comment {
     postTime = LocalDateTime.now();
   }
 
+  public void decreaseLikeCount() {
+    this.likeCount--;
+  }
+
   public void increaseLikeCount() {
     this.likeCount++;
   }

--- a/src/main/java/softeer/team_pineapple_be/domain/comment/response/CommentPageResponse.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/comment/response/CommentPageResponse.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import softeer.team_pineapple_be.domain.comment.domain.Comment;
+import softeer.team_pineapple_be.domain.comment.service.LikeRedisService;
 
 /**
  * 기대평 목록 응답
@@ -19,9 +20,10 @@ public class CommentPageResponse {
   private Integer totalPages;
   private List<CommentResponse> comments;
 
-  public static CommentPageResponse fromCommentPage(Page<Comment> comments) {
+  public static CommentPageResponse fromCommentPage(Page<Comment> comments, LikeRedisService likeRedisService) {
     List<Comment> content = comments.getContent();
-    List<CommentResponse> commentResponseList = content.stream().map(CommentResponse::fromComment).toList();
+    List<CommentResponse> commentResponseList =
+        content.stream().map(comment -> CommentResponse.fromComment(comment, likeRedisService)).toList();
     return new CommentPageResponse(comments.getTotalPages(), commentResponseList);
   }
 }

--- a/src/main/java/softeer/team_pineapple_be/domain/comment/response/CommentResponse.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/comment/response/CommentResponse.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import softeer.team_pineapple_be.domain.comment.domain.Comment;
+import softeer.team_pineapple_be.domain.comment.service.LikeRedisService;
 import softeer.team_pineapple_be.domain.comment.utils.PhoneNumberMasker;
 
 /**
@@ -20,9 +21,10 @@ public class CommentResponse {
   private String content;
   private Integer likeCount;
   private LocalDateTime postTime;
+  private Boolean isLiked;
 
-  public static CommentResponse fromComment(Comment comment) {
+  public static CommentResponse fromComment(Comment comment, LikeRedisService likeRedisService) {
     return new CommentResponse(comment.getId(), PhoneNumberMasker.maskPhoneNumber(comment.getPhoneNumber()),
-        comment.getContent(), comment.getLikeCount(), comment.getPostTime());
+        comment.getContent(), comment.getLikeCount(), comment.getPostTime(), likeRedisService.isLiked(comment.getId()));
   }
 }

--- a/src/main/java/softeer/team_pineapple_be/domain/comment/service/LikeRedisService.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/comment/service/LikeRedisService.java
@@ -1,0 +1,80 @@
+package softeer.team_pineapple_be.domain.comment.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.domain.comment.domain.CommentLike;
+import softeer.team_pineapple_be.domain.comment.domain.id.LikeId;
+import softeer.team_pineapple_be.domain.comment.repository.CommentLikeRepository;
+import softeer.team_pineapple_be.global.auth.context.AuthContext;
+import softeer.team_pineapple_be.global.auth.service.AuthMemberService;
+
+/**
+ * 레디스를 이용한 좋아요 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class LikeRedisService {
+  private static final String LIKE_PREFIX = "comment:";
+  private final RedisTemplate<String, String> redisTemplate;
+  private final AuthMemberService authMemberService;
+  private final CommentLikeRepository commentLikeRepository;
+
+  /**
+   * 좋아요 정보 레디스에 추가
+   *
+   * @param commentId
+   */
+  public void addLike(Long commentId) {
+    String memberPhoneNumber = authMemberService.getMemberPhoneNumber();
+    SetOperations<String, String> setOps = redisTemplate.opsForSet();
+    setOps.add(LIKE_PREFIX + commentId, memberPhoneNumber);
+  }
+
+  /**
+   * 빈 초기화 할 때 좋아요 정보 DB에서 꺼내서 올려놓기
+   */
+  @PostConstruct
+  public void initializeRedisStorage() {
+    List<CommentLike> allLikes = commentLikeRepository.findAll();
+    SetOperations<String, String> setOps = redisTemplate.opsForSet();
+    for (CommentLike commentLike : allLikes) {
+      LikeId commentIdAndPhoneNumber = commentLike.getId();
+      Long commentId = commentIdAndPhoneNumber.getCommentId();
+      String phoneNumber = commentIdAndPhoneNumber.getPhoneNumber();
+      setOps.add(LIKE_PREFIX + commentId, phoneNumber);
+    }
+  }
+
+  /**
+   * 자신이 좋아요 눌렀는지 확인
+   *
+   * @param commentId
+   * @return 좋아요 누름 여부
+   */
+  public Boolean isLiked(Long commentId) {
+    SetOperations<String, String> setOps = redisTemplate.opsForSet();
+    AuthContext authContext = authMemberService.getAuthContext();
+    if (authContext == null) {
+      return false;
+    }
+    String memberPhoneNumber = authContext.getPhoneNumber();
+    return setOps.isMember(LIKE_PREFIX + commentId, memberPhoneNumber);
+  }
+
+  /**
+   * 좋아요 취소
+   *
+   * @param commentId
+   */
+  public void removeLike(Long commentId) {
+    String memberPhoneNumber = authMemberService.getMemberPhoneNumber();
+    SetOperations<String, String> setOps = redisTemplate.opsForSet();
+    setOps.remove(LIKE_PREFIX + commentId, memberPhoneNumber);
+  }
+}

--- a/src/main/java/softeer/team_pineapple_be/global/auth/service/AuthMemberService.java
+++ b/src/main/java/softeer/team_pineapple_be/global/auth/service/AuthMemberService.java
@@ -6,6 +6,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import softeer.team_pineapple_be.global.auth.context.AuthContext;
 import softeer.team_pineapple_be.global.auth.context.AuthContextHolder;
 import softeer.team_pineapple_be.global.auth.exception.AuthErrorCode;
 import softeer.team_pineapple_be.global.exception.RestApiException;
@@ -17,16 +18,25 @@ import softeer.team_pineapple_be.global.exception.RestApiException;
 @RequiredArgsConstructor
 public class AuthMemberService {
   /**
+   * 인증 컨텍스트 반환
+   *
+   * @return 인증 컨텍스트
+   */
+  public AuthContext getAuthContext() {
+    return AuthContextHolder.getAuthContext();
+  }
+
+  /**
    * 인증된 멤버의 핸드폰번호를 세션에서 반환
    *
    * @return 핸드폰 번호 String
    */
   public String getMemberPhoneNumber() {
-    String phoneNumber = AuthContextHolder.getAuthContext().getPhoneNumber();
-    if (phoneNumber == null) {
+    AuthContext authContext = getAuthContext();
+    if (authContext == null) {
       throw new RestApiException(AuthErrorCode.NO_USER_INFO);
     }
-    return phoneNumber;
+    return authContext.getPhoneNumber();
   }
 
   private HttpServletRequest getCurrentRequest() {

--- a/src/main/java/softeer/team_pineapple_be/global/config/RedisConfig.java
+++ b/src/main/java/softeer/team_pineapple_be/global/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package softeer.team_pineapple_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * 레디스 설정
+ */
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory();
+  }
+
+  @Bean
+  public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feature/likes_with_redis

### 💡 작업동기
- 자신이 좋아요를 누른 기대평을 확인해야했다.
- 하지만 RDB만으로 구현하면 자신이 좋아요를 눌렀는지 확인하기 위해 DB에 과도한 쿼리가 발생하게 된다
- 따라서 레디스에 좋아요 정보를 저장하여 자신이 해당 기대평에 좋아요를 눌렀는지 여부를 빠르게 판단할 수 있게 했다.

### 🔑 주요 변경사항
- redis 추가
- 기대평 응답에 좋아요 누름 정보 추가

### 관련 이슈
- #45 
