### PR TITLE
Fix/#60,65/월드컵 통계 기능 버그 수정

### DIFF
--- a/src/main/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupRedisService.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupRedisService.java
@@ -29,7 +29,8 @@ public class WorldCupRedisService {
    * @return
    */
   public List<WorldCupResultResponse> getWorldCupResults() {
-    Set<ZSetOperations.TypedTuple<String>> tupleSet = redisTemplate.opsForZSet().rangeWithScores(ANSWER_KEY, 0, -1);
+    Set<ZSetOperations.TypedTuple<String>> tupleSet =
+        redisTemplate.opsForZSet().reverseRangeWithScores(ANSWER_KEY, 0, -1);
     long totalCount = tupleSet.stream().mapToLong(typedTuple -> typedTuple.getScore().longValue()).sum();
     List<WorldCupResultResponse> worldCupResultResponses = new ArrayList<>();
     tupleSet.forEach(typedTuple -> {

--- a/src/main/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupRedisService.java
+++ b/src/main/java/softeer/team_pineapple_be/domain/worldcup/service/WorldCupRedisService.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import softeer.team_pineapple_be.domain.worldcup.response.WorldCupResultResponse;
 
@@ -17,6 +18,8 @@ import softeer.team_pineapple_be.domain.worldcup.response.WorldCupResultResponse
 @RequiredArgsConstructor
 @Service
 public class WorldCupRedisService {
+  private final static int WORLD_CUP_ANSWER_ID_START = 1;
+  private final static int WORLD_CUP_ANSWER_ID_END = 6;
   private final static String ANSWER_KEY = "worldcup_cnt";
   private final RedisTemplate<String, String> redisTemplate;
 
@@ -44,5 +47,16 @@ public class WorldCupRedisService {
    */
   public void increaseAnswerIdCount(Integer worldCupAnswerId) {
     redisTemplate.opsForZSet().incrementScore(ANSWER_KEY, String.valueOf(worldCupAnswerId), 1);
+  }
+
+  /**
+   * 월드컵 통계 초기화 -> 아직 투표를 못받은 아이템을 0으로 초기화
+   */
+  @PostConstruct
+  public void init() {
+    ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+    for (int i = WORLD_CUP_ANSWER_ID_START; i <= WORLD_CUP_ANSWER_ID_END; i++) {
+      zSetOps.addIfAbsent(ANSWER_KEY, String.valueOf(i), 0);
+    }
   }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/worldcup_statistics

### 💡 작업동기
- 월드컵 통계가 선택 많은 순으로 정렬되어 나오지 않고 적은 순으로 정렬되어 나오는 버그 발생
- 월드컵에서 선택을 받지 않은 아이템들은 정보를 주지 않고 있었음

### 🔑 주요 변경사항
- 월드컵 통계 정보 선택 많은 순으로 정렬
- 월드컵에서 선택 못받은 아이템도 선택수 0으로 초기화해서 제공

### 관련 이슈
- #60 
- #65 